### PR TITLE
Implement rule handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +260,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -255,14 +273,18 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "globset",
  "matrix-sdk",
+ "matrix-sdk-test",
  "rand 0.8.4",
  "rpassword",
  "serde",
  "serde_json",
+ "serde_with",
  "tokio",
  "toml",
  "tracing",
+ "tracing-attributes",
  "tracing-subscriber",
 ]
 
@@ -358,6 +380,41 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -631,6 +688,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +832,12 @@ dependencies = [
  "tokio-rustls",
  "webpki",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -920,10 +996,10 @@ dependencies = [
  "futures-timer",
  "http",
  "matrix-sdk-base",
- "matrix-sdk-common",
+ "matrix-sdk-common 0.4.1",
  "mime",
  "reqwest",
- "ruma",
+ "ruma 0.4.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -945,11 +1021,11 @@ dependencies = [
  "futures",
  "hmac",
  "lru",
- "matrix-sdk-common",
+ "matrix-sdk-common 0.4.1",
  "matrix-sdk-crypto",
  "pbkdf2",
  "rand 0.8.4",
- "ruma",
+ "ruma 0.4.0",
  "serde",
  "serde_json",
  "sha2",
@@ -962,6 +1038,22 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-locks",
+ "instant",
+ "ruma 0.2.0",
+ "serde",
+ "tokio",
+ "uuid",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "matrix-sdk-common"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c004ca5d02a17eb827a2c3d8e34c9a84c075b42cfed7022895ba6418372ea5"
@@ -970,7 +1062,7 @@ dependencies = [
  "futures",
  "futures-locks",
  "instant",
- "ruma",
+ "ruma 0.4.0",
  "serde",
  "tokio",
  "uuid",
@@ -992,10 +1084,10 @@ dependencies = [
  "futures",
  "getrandom 0.2.3",
  "hmac",
- "matrix-sdk-common",
+ "matrix-sdk-common 0.4.1",
  "olm-rs",
  "pbkdf2",
- "ruma",
+ "ruma 0.4.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1004,6 +1096,25 @@ dependencies = [
  "tracing",
  "zeroize",
 ]
+
+[[package]]
+name = "matrix-sdk-test"
+version = "0.3.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
+dependencies = [
+ "http",
+ "lazy_static",
+ "matrix-sdk-common 0.3.0",
+ "matrix-sdk-test-macros",
+ "ruma 0.2.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "matrix-sdk-test-macros"
+version = "0.1.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
 
 [[package]]
 name = "memchr"
@@ -1374,6 +1485,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1454,21 +1567,54 @@ dependencies = [
 
 [[package]]
 name = "ruma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4acf77afac731e1fa133e6952d074af052f02d64909677a66619f52e758261"
+dependencies = [
+ "assign",
+ "js_int",
+ "ruma-api 0.17.1",
+ "ruma-client-api 0.11.0",
+ "ruma-common 0.5.4",
+ "ruma-events 0.23.3",
+ "ruma-identifiers 0.19.4",
+ "ruma-serde 0.4.2",
+]
+
+[[package]]
+name = "ruma"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668031e3108d6a2cfbe6eca271d8698f4593440e71a44afdadcf67ce3cb93c1f"
 dependencies = [
  "assign",
  "js_int",
- "ruma-api",
- "ruma-client-api",
- "ruma-common",
- "ruma-events",
+ "ruma-api 0.18.3",
+ "ruma-client-api 0.12.2",
+ "ruma-common 0.6.0",
+ "ruma-events 0.24.5",
  "ruma-federation-api",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "ruma-signatures",
  "ruma-state-res",
+]
+
+[[package]]
+name = "ruma-api"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6473753f244f057181f975224aeaf5b4e2003f43f2a6279bf0b95f4e0126335"
+dependencies = [
+ "bytes",
+ "http",
+ "percent-encoding",
+ "ruma-api-macros 0.17.1",
+ "ruma-identifiers 0.19.4",
+ "ruma-serde 0.4.2",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1480,12 +1626,24 @@ dependencies = [
  "bytes",
  "http",
  "percent-encoding",
- "ruma-api-macros",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-api-macros 0.18.3",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "ruma-api-macros"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85286e2c65897079e7dcc120964cca47d5a3c23b7d1e9f730f533060919fedf7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1502,6 +1660,27 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b86eba1c6fce6dd5c7a17ed632515aa7d04bbe6fbaa74c1699fb72c9fcc2d3d"
+dependencies = [
+ "assign",
+ "bytes",
+ "http",
+ "js_int",
+ "maplit",
+ "percent-encoding",
+ "ruma-api 0.17.1",
+ "ruma-common 0.5.4",
+ "ruma-events 0.23.3",
+ "ruma-identifiers 0.19.4",
+ "ruma-serde 0.4.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruma-client-api"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9568a222c12cf6220e751484ab78feec28071f85965113a5bb802936a2920ff0"
@@ -1512,13 +1691,29 @@ dependencies = [
  "js_int",
  "maplit",
  "percent-encoding",
- "ruma-api",
- "ruma-common",
- "ruma-events",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-api 0.18.3",
+ "ruma-common 0.6.0",
+ "ruma-events 0.24.5",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146a88f34b7a084d54eaf790aaf4c25f5d2366ca8f3d1f326985fa5d31d72595"
+dependencies = [
+ "indexmap",
+ "js_int",
+ "ruma-identifiers 0.19.4",
+ "ruma-serde 0.4.2",
+ "serde",
+ "serde_json",
+ "tracing",
+ "wildmatch",
 ]
 
 [[package]]
@@ -1529,12 +1724,28 @@ checksum = "41d5b7605f58dc0d9cf1848cc7f1af2bae4e4bcd1d2b7a87bbb9864c8a785b91"
 dependencies = [
  "indexmap",
  "js_int",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
  "tracing",
  "wildmatch",
+]
+
+[[package]]
+name = "ruma-events"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da5f1472d60803e06744f83040a055948fd5bc1f4344d3e555ea378d0d6c96d"
+dependencies = [
+ "indoc",
+ "js_int",
+ "ruma-common 0.5.4",
+ "ruma-events-macros 0.23.3",
+ "ruma-identifiers 0.19.4",
+ "ruma-serde 0.4.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1545,13 +1756,25 @@ checksum = "87801e1207cfebdee02e7997ebf181a1c9837260b78c1b8ce96b896a2bcb3763"
 dependencies = [
  "indoc",
  "js_int",
- "ruma-common",
- "ruma-events-macros",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-common 0.6.0",
+ "ruma-events-macros 0.24.5",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "ruma-events-macros"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85929d84b29c4ce034bd1742e13d7ca25d885831f0185b73f7f9a9094296e1c4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1573,13 +1796,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa3d1db1a064ab26484df6ef5d96c384fc053022004f34d96c3b4939e13dc204"
 dependencies = [
  "js_int",
- "ruma-api",
- "ruma-common",
- "ruma-events",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-api 0.18.3",
+ "ruma-common 0.6.0",
+ "ruma-events 0.24.5",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ruma-identifiers"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be9ce339ce206dd5eb5eb29b7ad1b964652d46345bc46f25d68105effc75f4b"
+dependencies = [
+ "paste",
+ "ruma-identifiers-macros 0.19.4",
+ "ruma-identifiers-validation 0.4.0",
+ "ruma-serde 0.4.2",
+ "ruma-serde-macros 0.4.2",
+ "serde",
 ]
 
 [[package]]
@@ -1589,11 +1826,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb417d091e8dd5a633e4e5998231a156049d7fcc221045cfdc0642eb72067732"
 dependencies = [
  "paste",
- "ruma-identifiers-macros",
- "ruma-identifiers-validation",
- "ruma-serde",
- "ruma-serde-macros",
+ "ruma-identifiers-macros 0.20.0",
+ "ruma-identifiers-validation 0.5.0",
+ "ruma-serde 0.5.0",
+ "ruma-serde-macros 0.5.0",
  "serde",
+]
+
+[[package]]
+name = "ruma-identifiers-macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c7bc7e132a84f8d03924cf63d3a37bd87ffee5c29fee69b9125d045c7e4020"
+dependencies = [
+ "quote",
+ "ruma-identifiers-validation 0.4.0",
+ "syn",
 ]
 
 [[package]]
@@ -1603,15 +1851,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c708edad7f605638f26c951cbad7501fbf28ab01009e5ca65ea5a2db74a882b1"
 dependencies = [
  "quote",
- "ruma-identifiers-validation",
+ "ruma-identifiers-validation 0.5.0",
  "syn",
 ]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edeb165c4dcb8c93d1b7396b32fd5f52c5d9c7e7898ab87d772f824fe642f7c"
 
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42285e7fb5d5f2d5268e45bb683e36d5c6fd9fc1e11a4559ba3c3521f3bbb2cb"
+
+[[package]]
+name = "ruma-serde"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9cf55470945ce15641f331d0230bbab328cdf9aa5c3ec8aa20977b60553f15"
+dependencies = [
+ "bytes",
+ "form_urlencoded",
+ "itoa",
+ "js_int",
+ "ruma-serde-macros 0.4.2",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "ruma-serde"
@@ -1623,9 +1892,21 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "js_int",
- "ruma-serde-macros",
+ "ruma-serde-macros 0.5.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ruma-serde-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6af6e7156da1a4b0bd4b13dbe8c5a725878595a7962345393b3f171c75bd7cc"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1650,8 +1931,8 @@ dependencies = [
  "ed25519-dalek",
  "pkcs8",
  "rand 0.7.3",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde_json",
  "sha2",
  "thiserror",
@@ -1666,10 +1947,10 @@ checksum = "518c1afbddfcc5ffac8818a5cf0902709e6eca11aca8f24f6479df6f0601f1ba"
 dependencies = [
  "itertools",
  "js_int",
- "ruma-common",
- "ruma-events",
- "ruma-identifiers",
- "ruma-serde",
+ "ruma-common 0.6.0",
+ "ruma-events 0.24.5",
+ "ruma-identifiers 0.20.0",
+ "ruma-serde 0.5.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1697,6 +1978,12 @@ dependencies = [
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1782,6 +2069,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1934,6 +2244,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2126,9 +2442,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2138,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2189,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d29c0f56bcd17117430bc60fd10624b419ab8a3b5c358796a31e9a37a83a65"
+checksum = "62af966210b88ad5776ee3ba12d5f35b8d6a2b2a12168f3080cf02b814d7376b"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,11 +271,9 @@ name = "clobber"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "globset",
  "matrix-sdk",
- "matrix-sdk-test",
  "rand 0.8.4",
  "rpassword",
  "serde",
@@ -996,10 +994,10 @@ dependencies = [
  "futures-timer",
  "http",
  "matrix-sdk-base",
- "matrix-sdk-common 0.4.1",
+ "matrix-sdk-common",
  "mime",
  "reqwest",
- "ruma 0.4.0",
+ "ruma",
  "serde",
  "serde_json",
  "thiserror",
@@ -1021,11 +1019,11 @@ dependencies = [
  "futures",
  "hmac",
  "lru",
- "matrix-sdk-common 0.4.1",
+ "matrix-sdk-common",
  "matrix-sdk-crypto",
  "pbkdf2",
  "rand 0.8.4",
- "ruma 0.4.0",
+ "ruma",
  "serde",
  "serde_json",
  "sha2",
@@ -1038,22 +1036,6 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-common"
-version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
-dependencies = [
- "async-trait",
- "futures",
- "futures-locks",
- "instant",
- "ruma 0.2.0",
- "serde",
- "tokio",
- "uuid",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "matrix-sdk-common"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c004ca5d02a17eb827a2c3d8e34c9a84c075b42cfed7022895ba6418372ea5"
@@ -1062,7 +1044,7 @@ dependencies = [
  "futures",
  "futures-locks",
  "instant",
- "ruma 0.4.0",
+ "ruma",
  "serde",
  "tokio",
  "uuid",
@@ -1084,10 +1066,10 @@ dependencies = [
  "futures",
  "getrandom 0.2.3",
  "hmac",
- "matrix-sdk-common 0.4.1",
+ "matrix-sdk-common",
  "olm-rs",
  "pbkdf2",
- "ruma 0.4.0",
+ "ruma",
  "serde",
  "serde_json",
  "sha2",
@@ -1096,25 +1078,6 @@ dependencies = [
  "tracing",
  "zeroize",
 ]
-
-[[package]]
-name = "matrix-sdk-test"
-version = "0.3.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
-dependencies = [
- "http",
- "lazy_static",
- "matrix-sdk-common 0.3.0",
- "matrix-sdk-test-macros",
- "ruma 0.2.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "matrix-sdk-test-macros"
-version = "0.1.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=4d57681#4d5768111d99d7c5b4319621d333233a11449b9b"
 
 [[package]]
 name = "memchr"
@@ -1567,54 +1530,21 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4acf77afac731e1fa133e6952d074af052f02d64909677a66619f52e758261"
-dependencies = [
- "assign",
- "js_int",
- "ruma-api 0.17.1",
- "ruma-client-api 0.11.0",
- "ruma-common 0.5.4",
- "ruma-events 0.23.3",
- "ruma-identifiers 0.19.4",
- "ruma-serde 0.4.2",
-]
-
-[[package]]
-name = "ruma"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "668031e3108d6a2cfbe6eca271d8698f4593440e71a44afdadcf67ce3cb93c1f"
 dependencies = [
  "assign",
  "js_int",
- "ruma-api 0.18.3",
- "ruma-client-api 0.12.2",
- "ruma-common 0.6.0",
- "ruma-events 0.24.5",
+ "ruma-api",
+ "ruma-client-api",
+ "ruma-common",
+ "ruma-events",
  "ruma-federation-api",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-identifiers",
+ "ruma-serde",
  "ruma-signatures",
  "ruma-state-res",
-]
-
-[[package]]
-name = "ruma-api"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6473753f244f057181f975224aeaf5b4e2003f43f2a6279bf0b95f4e0126335"
-dependencies = [
- "bytes",
- "http",
- "percent-encoding",
- "ruma-api-macros 0.17.1",
- "ruma-identifiers 0.19.4",
- "ruma-serde 0.4.2",
- "serde",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -1626,24 +1556,12 @@ dependencies = [
  "bytes",
  "http",
  "percent-encoding",
- "ruma-api-macros 0.18.3",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-api-macros",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ruma-api-macros"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85286e2c65897079e7dcc120964cca47d5a3c23b7d1e9f730f533060919fedf7"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1660,27 +1578,6 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b86eba1c6fce6dd5c7a17ed632515aa7d04bbe6fbaa74c1699fb72c9fcc2d3d"
-dependencies = [
- "assign",
- "bytes",
- "http",
- "js_int",
- "maplit",
- "percent-encoding",
- "ruma-api 0.17.1",
- "ruma-common 0.5.4",
- "ruma-events 0.23.3",
- "ruma-identifiers 0.19.4",
- "ruma-serde 0.4.2",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ruma-client-api"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9568a222c12cf6220e751484ab78feec28071f85965113a5bb802936a2920ff0"
@@ -1691,29 +1588,13 @@ dependencies = [
  "js_int",
  "maplit",
  "percent-encoding",
- "ruma-api 0.18.3",
- "ruma-common 0.6.0",
- "ruma-events 0.24.5",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-api",
+ "ruma-common",
+ "ruma-events",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ruma-common"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146a88f34b7a084d54eaf790aaf4c25f5d2366ca8f3d1f326985fa5d31d72595"
-dependencies = [
- "indexmap",
- "js_int",
- "ruma-identifiers 0.19.4",
- "ruma-serde 0.4.2",
- "serde",
- "serde_json",
- "tracing",
- "wildmatch",
 ]
 
 [[package]]
@@ -1724,28 +1605,12 @@ checksum = "41d5b7605f58dc0d9cf1848cc7f1af2bae4e4bcd1d2b7a87bbb9864c8a785b91"
 dependencies = [
  "indexmap",
  "js_int",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
  "tracing",
  "wildmatch",
-]
-
-[[package]]
-name = "ruma-events"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da5f1472d60803e06744f83040a055948fd5bc1f4344d3e555ea378d0d6c96d"
-dependencies = [
- "indoc",
- "js_int",
- "ruma-common 0.5.4",
- "ruma-events-macros 0.23.3",
- "ruma-identifiers 0.19.4",
- "ruma-serde 0.4.2",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1756,25 +1621,13 @@ checksum = "87801e1207cfebdee02e7997ebf181a1c9837260b78c1b8ce96b896a2bcb3763"
 dependencies = [
  "indoc",
  "js_int",
- "ruma-common 0.6.0",
- "ruma-events-macros 0.24.5",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-common",
+ "ruma-events-macros",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ruma-events-macros"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85929d84b29c4ce034bd1742e13d7ca25d885831f0185b73f7f9a9094296e1c4"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1796,27 +1649,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa3d1db1a064ab26484df6ef5d96c384fc053022004f34d96c3b4939e13dc204"
 dependencies = [
  "js_int",
- "ruma-api 0.18.3",
- "ruma-common 0.6.0",
- "ruma-events 0.24.5",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-api",
+ "ruma-common",
+ "ruma-events",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ruma-identifiers"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be9ce339ce206dd5eb5eb29b7ad1b964652d46345bc46f25d68105effc75f4b"
-dependencies = [
- "paste",
- "ruma-identifiers-macros 0.19.4",
- "ruma-identifiers-validation 0.4.0",
- "ruma-serde 0.4.2",
- "ruma-serde-macros 0.4.2",
- "serde",
 ]
 
 [[package]]
@@ -1826,22 +1665,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb417d091e8dd5a633e4e5998231a156049d7fcc221045cfdc0642eb72067732"
 dependencies = [
  "paste",
- "ruma-identifiers-macros 0.20.0",
- "ruma-identifiers-validation 0.5.0",
- "ruma-serde 0.5.0",
- "ruma-serde-macros 0.5.0",
+ "ruma-identifiers-macros",
+ "ruma-identifiers-validation",
+ "ruma-serde",
+ "ruma-serde-macros",
  "serde",
-]
-
-[[package]]
-name = "ruma-identifiers-macros"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c7bc7e132a84f8d03924cf63d3a37bd87ffee5c29fee69b9125d045c7e4020"
-dependencies = [
- "quote",
- "ruma-identifiers-validation 0.4.0",
- "syn",
 ]
 
 [[package]]
@@ -1851,36 +1679,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c708edad7f605638f26c951cbad7501fbf28ab01009e5ca65ea5a2db74a882b1"
 dependencies = [
  "quote",
- "ruma-identifiers-validation 0.5.0",
+ "ruma-identifiers-validation",
  "syn",
 ]
-
-[[package]]
-name = "ruma-identifiers-validation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edeb165c4dcb8c93d1b7396b32fd5f52c5d9c7e7898ab87d772f824fe642f7c"
 
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42285e7fb5d5f2d5268e45bb683e36d5c6fd9fc1e11a4559ba3c3521f3bbb2cb"
-
-[[package]]
-name = "ruma-serde"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9cf55470945ce15641f331d0230bbab328cdf9aa5c3ec8aa20977b60553f15"
-dependencies = [
- "bytes",
- "form_urlencoded",
- "itoa",
- "js_int",
- "ruma-serde-macros 0.4.2",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "ruma-serde"
@@ -1892,21 +1699,9 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "js_int",
- "ruma-serde-macros 0.5.0",
+ "ruma-serde-macros",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ruma-serde-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af6e7156da1a4b0bd4b13dbe8c5a725878595a7962345393b3f171c75bd7cc"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1931,8 +1726,8 @@ dependencies = [
  "ed25519-dalek",
  "pkcs8",
  "rand 0.7.3",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde_json",
  "sha2",
  "thiserror",
@@ -1947,10 +1742,10 @@ checksum = "518c1afbddfcc5ffac8818a5cf0902709e6eca11aca8f24f6479df6f0601f1ba"
 dependencies = [
  "itertools",
  "js_int",
- "ruma-common 0.6.0",
- "ruma-events 0.24.5",
- "ruma-identifiers 0.20.0",
- "ruma-serde 0.5.0",
+ "ruma-common",
+ "ruma-events",
+ "ruma-identifiers",
+ "ruma-serde",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ tracing-subscriber = { version = "0.2", features = ["parking_lot"] }
 rpassword = "5.0"
 rand = "0.8"
 clap = "2.33"
-async-trait = "0.1"
 tracing-attributes = "0.1.15"
 serde_with = "1.9.4"
 globset = "0.4.8"
@@ -28,7 +27,3 @@ globset = "0.4.8"
 version = "0.4"
 default_features = false
 features = ["encryption", "sled_cryptostore", "sled_state_store", "rustls-tls"]
-
-[dependencies.matrix-sdk-test]
-git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "4d57681"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,16 @@ rpassword = "5.0"
 rand = "0.8"
 clap = "2.33"
 async-trait = "0.1"
-# matrix-sdk-common-macros = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "d9e5a17" }
+tracing-attributes = "0.1.15"
+serde_with = "1.9.4"
+globset = "0.4.8"
+
 
 [dependencies.matrix-sdk]
 version = "0.4"
 default_features = false
 features = ["encryption", "sled_cryptostore", "sled_state_store", "rustls-tls"]
+
+[dependencies.matrix-sdk-test]
+git = "https://github.com/matrix-org/matrix-rust-sdk"
+rev = "4d57681"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Moderation bot for matrix.
 
+## Usage
+
+Login interactively with `clobber --login` the first time the bot is started. If login is successful, the session is stored and the bot can subsequently be started by simply running `clobber`.
+
 ## Planned features
 
 - [x] Matrix & bot base
@@ -17,6 +21,7 @@ Moderation bot for matrix.
       - [ ] ACL management
       - [ ] Ban management
       - [ ] PL management
+      - [ ] Rule list management
   - [x] Command handling
     - [ ] kick
     - [ ] ban
@@ -37,6 +42,7 @@ Moderation bot for matrix.
 ## TODO
 
 - When management room is implemented, allow all members of room to invite the bot
+- Perform PL checking
 - Restructure configuration and initial login
 - Settle on consistent style for documentation
 - Refactor command handling, generate help text for commands automatically etc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clobber
 
-Moderation bot for matrix.
+Moderation bot for matrix. Heavily inspired by [mjolnir](https://github.com/matrix-org/mjolnir), but not a drop-in replacement. This might change in the future in case this is ever stable enough.
 
 ## Usage
 

--- a/planning.md
+++ b/planning.md
@@ -1,0 +1,71 @@
+# Clobber planning document
+
+## Events
+### `sh.nao.clobber.rule`
+```json
+{
+	"content": {
+		"action": "ban",
+		"entity": "@user:domain.tld",
+		"reason": "spam"
+	},
+	"origin_server_ts": 1628599214338,
+	"sender": "@mod:domain.tld",
+	"state_key": "r:@user:domain.tld",
+	"type": "sh.nao.clobber.list",
+	"unsigned": {
+		"age": 3083577327
+	},
+	"event_id": "$rRP4MvqZsS7lEmihlO2ltkl7cFgoR-uqXalagHW08EI",
+	"room_id": "!BqCrVFYKvHgjnsFYss:domain.tld"
+}
+```
+
+### `sh.nao.clobber.shortcode`
+```json
+{
+	"type": "sh.nao.clobber.shortcode",
+	"sender": "@mod:domain.tld",
+	"content": {
+		"shortcode": "spam"
+	},
+	"state_key": "",
+	"origin_server_ts": 1609078000256,
+	"unsigned": {
+		"age": 22623721274
+	},
+	"event_id": "$1RNXRgcokp_895QlB6tfy6JqF98IrcaPagJ2UCtCWXg",
+	"room_id": "!klUPWJCnPTTbuLGDwY:domain.tld"
+}
+```
+
+## Account data
+### `sh.nao.clobber.protected_rooms`
+```json
+{
+	"type": "sh.nao.clobber.protected_rooms",
+	"content": {
+		"rooms": ]
+			"!room1:domain.tld",
+			"!room2:domain.tld"
+		]
+	}
+}
+```
+
+### `sh.nao.clobber.watched_lists`
+```json
+{
+	"type": "sh.nao.clobber.watched_lists",
+	"content": {
+		"lists": {
+			"spam": {
+				"room": "!room1:domain.tld",
+			},
+			"coc": {
+				"room": "!room2:domain.tld",
+			}
+		}
+	}
+}
+```

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -4,60 +4,75 @@
 
 //! Bot functionality, command handling, etc.
 
+use anyhow::{anyhow, Error};
+use globset::Glob;
 use matrix_sdk::{
     room::{Joined, Room},
-    ruma::events::{
-        room::{
-            member::{MemberEventContent, MembershipState},
-            message::{
-                InReplyTo, MessageEventContent, MessageType, Relation, TextMessageEventContent,
-            },
-        },
-        AnyMessageEventContent, StrippedStateEvent, SyncMessageEvent, SyncStateEvent,
-    },
     ruma::EventId,
+    ruma::{events::AnySyncStateEvent, RoomId},
+    ruma::{
+        events::{
+            macros::EventContent,
+            room::{
+                member::{MemberEventContent, MembershipState},
+                message::{
+                    InReplyTo, MessageEventContent, MessageType, Relation, TextMessageEventContent,
+                },
+            },
+            AnyMessageEventContent, AnyStateEventContent, EventType, StrippedStateEvent,
+            SyncMessageEvent, SyncStateEvent,
+        },
+        int, UserId,
+    },
     Client,
 };
 use serde::{Deserialize, Serialize};
+use serde_with::rust::string_empty_as_none;
+use std::convert::TryFrom;
 use std::time::Duration;
-use tracing::instrument;
-
 use tokio::time::sleep;
+use tracing_attributes::instrument;
+
 #[allow(unused_imports)]
 use tracing::{debug, error, info, warn};
 
 use crate::config::Config;
 
 /// Enum of available actions to apply to entity that matches rules.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Action {
-    /// Ban the entity from the room.
+    /// Ban the entity.
     Ban,
+    /// Kick the entity.
+    Kick,
+    /// Mute the entity.
+    Mute,
 }
 
-/// Enum of available rule list event types.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum List {
-    /// List of rules containing User IDs or globs.
-    #[serde(rename = "sh.nao.list.user")]
-    User {
-        /// The user(s) the rule applies to.
-        entity: String,
-        /// The action to take on successful match.
-        action: Action,
-        /// User-supplied reason for creating the rule.
-        reason: String,
-    },
-    /// List of rules containing server names or globs.
-    #[serde(rename = "sh.nao.list.server")]
-    Server {
-        /// The server(s) the rule applies to.
-        entity: String,
-        /// The action to take on successful match.
-        action: Action,
-        /// User-supplied reason for creating the rule.
-        reason: String,
-    },
+/// Custom `EventContent` type for `sh.nao.clibber.rule.user` events.
+#[derive(Clone, Serialize, Deserialize, Debug, EventContent)]
+#[ruma_event(type = "sh.nao.clobber.rule.user", kind = State)]
+pub struct UserRuleEventContent {
+    /// The user(s) the rule applies to.
+    entity: String,
+    /// The action to take on successful match.
+    action: Action,
+    /// User-supplied reason for creating the rule.
+    #[serde(with = "string_empty_as_none")]
+    reason: Option<String>,
+}
+
+/// Custom `EventContent` type for `sh.nao.clibber.rule.server` events.
+#[derive(Clone, Serialize, Deserialize, Debug, EventContent)]
+#[ruma_event(type = "sh.nao.clobber.rule.server", kind = State)]
+pub struct ServerRuleEventContent {
+    /// The user(s) the rule applies to.
+    entity: String,
+    /// The action to take on successful match.
+    action: Action,
+    /// User-supplied reason for creating the rule.
+    #[serde(with = "string_empty_as_none")]
+    reason: Option<String>,
 }
 
 #[instrument]
@@ -119,12 +134,14 @@ pub async fn on_stripped_state_member(
 
 #[instrument]
 pub async fn on_room_member(event: SyncStateEvent<MemberEventContent>, room: Room, client: Client) {
-    if let Room::Joined(_room) = room {
+    if let Room::Joined(room) = room {
         info!("Event handler firing");
+        check_member(&event, &room, &client).await.unwrap();
     };
 }
 
 /// Handles incoming commands and dispatches relevant functions.
+#[instrument]
 async fn handle_command(
     event: &SyncMessageEvent<MessageEventContent>,
     room: &Joined,
@@ -145,6 +162,7 @@ async fn handle_command(
 }
 
 /// Fallback when an unrecognized command is invoked.
+#[instrument]
 async fn command_unknown(
     event: &SyncMessageEvent<MessageEventContent>,
     room: &Joined,
@@ -188,6 +206,7 @@ async fn send_reply(
 
 // Inspired by the AutoJoin example in matrix-rust-sdk
 /// Handles incoming invites.
+#[instrument]
 async fn accept_invite(
     event: &StrippedStateEvent<MemberEventContent>,
     room: &Room,
@@ -212,7 +231,7 @@ async fn accept_invite(
         // has passed.
         debug!("Joining room: {}", room.room_id());
         let mut delay = 2;
-        while let Err(e) = client.join_room_by_id(room.room_id()).await {
+        while let Err(e) = room.accept_invitation().await {
             warn!(
                 "Failed to join room: {} ({:?}), retrying in {}s",
                 room.room_id(),
@@ -230,4 +249,282 @@ async fn accept_invite(
         info!("Joined room: {}", room.room_id());
     }
     Ok(())
+}
+
+/// Called on `m.room.member` events. Checks whether the user matches any of the rules, and calls
+/// `apply_rule()` if they do.
+#[instrument]
+async fn check_member(
+    event: &SyncStateEvent<MemberEventContent>,
+    room: &Joined,
+    client: &Client,
+) -> Result<(), anyhow::Error> {
+    // Check `invite`, `join` and `knock` states against rule lists and apply ban if there's a match
+    if event.content.membership == MembershipState::Invite
+        || event.content.membership == MembershipState::Join
+        || event.content.membership == MembershipState::Knock
+    {
+        let mut events = get_user_rules(client, room, event).await?;
+        events.sort_by_key(|e| e.content.action);
+        if let Some(event) = events.first() {
+            apply_rule(
+                room,
+                UserId::try_from(event.state_key.clone())?,
+                event.content.action,
+                event.content.reason.as_deref(),
+            )
+            .await?;
+        };
+
+        let mut events = get_server_rules(client, room, event).await?;
+        events.sort_by_key(|e| e.content.action);
+        if let Some(event) = events.first() {
+            apply_rule(
+                room,
+                UserId::try_from(event.state_key.clone())?,
+                event.content.action,
+                event.content.reason.as_deref(),
+            )
+            .await?;
+        };
+    }
+    Ok(())
+}
+
+/// Apply a moderation action to a user based on the rule. The action taken is ordered by severity, decided by the definition order of the `Action` enum.
+async fn apply_rule(
+    room: &Joined,
+    user: UserId,
+    action: Action,
+    reason: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    // TODO: Write tests for these actions
+    match action {
+        Action::Ban => {
+            room.ban_user(&user, reason).await?;
+        }
+        Action::Kick => {
+            room.kick_user(&user, reason).await?;
+        }
+        Action::Mute => {
+            let powerlevel = room
+                .get_state_event(EventType::RoomPowerLevels, "")
+                .await?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "There is no `m.room.power_levels` event in {}! Something is very wrong.",
+                        room.room_id()
+                    )
+                })?
+                .deserialize()?;
+            let mut powerlevel = match powerlevel {
+                AnySyncStateEvent::RoomPowerLevels(e) => e.content,
+                _ => {
+                    return Err(anyhow!(
+                        "Incorrect event type returned by `Joined::get_state_event()`"
+                    ))
+                }
+            };
+            powerlevel.users.insert(user, int!(-1));
+            room.send_state_event(AnyStateEventContent::RoomPowerLevels(powerlevel), "")
+                .await?;
+        }
+    };
+    Ok(())
+}
+
+// There are opportunities for code reuse in this function and `get_server_rules()`, I just don't know how to do it well. A solution with generics was attempted but the cost ended up outweighing the benefits.
+/// Returns a `Vec` with state events containing user rules.
+#[instrument]
+async fn get_user_rules(
+    client: &Client,
+    room: &Joined,
+    room_member: &SyncStateEvent<MemberEventContent>,
+) -> Result<Vec<SyncStateEvent<UserRuleEventContent>>, Error> {
+    let mut events = Vec::new();
+    for r in mock_room_list() {
+        debug!("{:?}", r);
+        let rule_room = match client.get_joined_room(&r) {
+            Some(room) => room,
+            None => continue,
+        };
+        let events_inner = rule_room
+            .get_state_events(EventType::from("sh.nao.clobber.rule.user"))
+            .await
+            .unwrap();
+        let events_inner: Vec<SyncStateEvent<UserRuleEventContent>> = events_inner
+            .iter()
+            .filter_map(|e| {
+                e.deserialize_as::<SyncStateEvent<UserRuleEventContent>>()
+                    .ok()
+            })
+            .filter(|e| {
+                is_match_user_rule(
+                    UserId::try_from(room_member.state_key.clone()).unwrap(),
+                    &e.content,
+                )
+                .unwrap()
+            })
+            .collect();
+        events.extend(events_inner);
+    }
+    Ok(events)
+}
+
+/// Returns a `Vec` with state events containing server rules.
+#[instrument]
+async fn get_server_rules(
+    client: &Client,
+    room: &Joined,
+    room_member: &SyncStateEvent<MemberEventContent>,
+) -> Result<Vec<SyncStateEvent<ServerRuleEventContent>>, Error> {
+    let mut events = Vec::new();
+    for r in mock_room_list() {
+        debug!("{:?}", r);
+        let rule_room = match client.get_joined_room(&r) {
+            Some(room) => room,
+            None => continue,
+        };
+        let events_inner = rule_room
+            .get_state_events(EventType::from("sh.nao.clobber.rule.server"))
+            .await
+            .unwrap();
+        let events_inner: Vec<SyncStateEvent<ServerRuleEventContent>> = events_inner
+            .iter()
+            .filter_map(|e| {
+                e.deserialize_as::<SyncStateEvent<ServerRuleEventContent>>()
+                    .ok()
+            })
+            .filter(|e| {
+                is_match_server_rule(
+                    UserId::try_from(room_member.state_key.clone()).unwrap(),
+                    &e.content,
+                )
+            })
+            .collect();
+        events.extend(events_inner);
+    }
+    Ok(events)
+}
+
+/// Checks a `UserId` against a user rule and returns true if it matches.
+fn is_match_user_rule(user_id: UserId, rule: &UserRuleEventContent) -> Result<bool, anyhow::Error> {
+    debug!("{:?}", rule);
+    let glob = Glob::new(&rule.entity)?.compile_matcher();
+    let user_id = user_id;
+    Ok(glob.is_match(user_id.as_str()))
+}
+
+/// Checks a `UserId` against a server rule and returns true if it matches.
+fn is_match_server_rule(user_id: UserId, rule: &ServerRuleEventContent) -> bool {
+    debug!("{:?}", rule);
+    let glob = Glob::new(&rule.entity).unwrap().compile_matcher();
+    let user_id = user_id;
+    glob.is_match(user_id.server_name().as_str())
+}
+
+/// Creates an example room list. Placeholder until actual room lists can be fetched from account data.
+fn mock_room_list() -> Vec<RoomId> {
+    vec![RoomId::try_from("!BqCrVFYKvHgjnsFYss:queersin.space").unwrap()]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use matrix_sdk::ruma::UserId;
+    #[allow(unused_imports)]
+    use tracing::{debug, error, info, warn};
+
+    use super::{
+        is_match_server_rule, is_match_user_rule, Action, ServerRuleEventContent,
+        UserRuleEventContent,
+    };
+
+    #[tokio::test]
+    #[allow(clippy::semicolon_if_nothing_returned)]
+    async fn test_server_rules() {
+        let baduser1: UserId = UserId::try_from("@foobar:badserver.tld").unwrap();
+        let baduser2: UserId = UserId::try_from("@foobar:subdomain.badserver.tld").unwrap();
+
+        let full = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let tld = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("*.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let full_miss = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("goodserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let glob_miss = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("*.goodserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let tld_miss = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("*.xyz"),
+            reason: Some(String::from("spam")),
+        };
+
+        assert!(is_match_server_rule(baduser1.clone(), &full));
+        assert!(is_match_server_rule(baduser1.clone(), &tld));
+
+        assert!(!is_match_server_rule(baduser1.clone(), &full_miss));
+        assert!(!is_match_server_rule(baduser1.clone(), &glob_miss));
+        assert!(!is_match_server_rule(baduser1, &tld_miss));
+
+        let glob = ServerRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("*.badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        assert!(is_match_server_rule(baduser2, &glob));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::semicolon_if_nothing_returned)]
+    async fn test_user_rules() {
+        let user_id: UserId = UserId::try_from("@foobar:badserver.tld").unwrap();
+
+        let full = UserRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("@foobar:badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let glob = UserRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("@foo*:badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let full_miss = UserRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("@bob:badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        let glob_miss = UserRuleEventContent {
+            action: Action::Ban,
+            entity: String::from("@*bob:badserver.tld"),
+            reason: Some(String::from("spam")),
+        };
+
+        assert!(is_match_user_rule(user_id.clone(), &full).unwrap());
+        assert!(is_match_user_rule(user_id.clone(), &glob).unwrap());
+        assert!(!is_match_user_rule(user_id.clone(), &full_miss).unwrap());
+        assert!(!is_match_user_rule(user_id, &glob_miss).unwrap());
+    }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -6,10 +6,7 @@
 
 use matrix_sdk::{
     room::Joined,
-    ruma::{
-        events::{room::message::MessageEventContent, SyncMessageEvent},
-        UserId,
-    },
+    ruma::events::{room::message::MessageEventContent, SyncMessageEvent},
     Client,
 };
 use tracing::instrument;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,111 @@
+// Clobber - a matrix moderation bot
+// Copyright (C) 2020 Emelie <em@nao.sh>
+// Licensed under the EUPL
+
+//! Command functions and dispatch.
+
+use matrix_sdk::{
+    room::Joined,
+    ruma::{
+        events::{room::message::MessageEventContent, SyncMessageEvent},
+        UserId,
+    },
+    Client,
+};
+use tracing::instrument;
+
+use crate::{bot, config::Config};
+
+/// Handles incoming commands and dispatches relevant functions.
+#[instrument]
+pub async fn handle_command(
+    event: &SyncMessageEvent<MessageEventContent>,
+    room: &Joined,
+    client: &Client,
+    commands: Vec<&str>,
+    config: &Config,
+) -> anyhow::Result<()> {
+    if commands.len() < 2 {
+        help(event, room).await?;
+        return Ok(());
+    }
+    let base_command = commands[1];
+    let arguments = &commands[2..];
+    match base_command {
+        "help" => help(event, room).await?,
+        "ban" => ban(event, room, client, config, arguments.to_vec()).await?,
+        _ => unknown(event, room, config).await?,
+    }
+    Ok(())
+}
+
+/// Fallback when an unrecognized command is invoked.
+#[instrument]
+async fn unknown(
+    event: &SyncMessageEvent<MessageEventContent>,
+    room: &Joined,
+    config: &Config,
+) -> anyhow::Result<()> {
+    bot::send_reply(
+        &format!("Unrecognized command, please try again or see {} help for available commands.", &config.bot.command_prefix),
+        &format!("Unrecognized command, please try again or see <code>{} help</code> for available commands.", &config.bot.command_prefix),
+        room,
+        event.event_id.clone(),
+    ).await?;
+    Ok(())
+}
+
+/// Send help information.
+#[instrument]
+async fn help(event: &SyncMessageEvent<MessageEventContent>, room: &Joined) -> anyhow::Result<()> {
+    let message = "There's nothing here yet";
+    bot::send_reply(message, message, room, event.event_id.clone()).await?;
+    Ok(())
+}
+
+/// Ban a user.
+#[instrument]
+async fn ban(
+    event: &SyncMessageEvent<MessageEventContent>,
+    room: &Joined,
+    client: &Client,
+    config: &Config,
+    args: Vec<&str>,
+) -> anyhow::Result<()> {
+    let (list, entity, reason) = match args.as_slice() {
+        [list, entity] => (list, entity, None),
+        [list, entity, reason] => (list, entity, Some(*reason)),
+        _ => {
+            let message = "Invalid number of arguments!";
+            bot::send_reply(message, message, room, event.event_id.clone()).await?;
+            return Ok(());
+        }
+    };
+    bot::set_rule(
+        client,
+        &bot::get_list_room(client, list).await?,
+        entity,
+        bot::Action::Ban,
+        reason,
+    )
+    .await?;
+    for room in bot::get_protected_rooms(client)
+        .await?
+        .iter()
+        .filter_map(|room_id| client.get_joined_room(room_id))
+    {
+        let matching_users: Vec<UserId> = room
+            .joined_members()
+            .await?
+            .iter()
+            .filter(|member| {
+                bot::is_match_entity(member.user_id().clone(), entity.to_string()).unwrap_or(false)
+            })
+            .map(|member| member.user_id().to_owned())
+            .collect();
+        for user in matching_users.iter() {
+            room.ban_user(user, reason).await?;
+        }
+    }
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@
 
 //! Configuration related functionality.
 
-use anyhow::Result;
 use matrix_sdk::ruma::UserId;
 use serde::{Deserialize, Serialize};
 use std::os::unix::fs::PermissionsExt;
@@ -24,7 +23,7 @@ pub struct Config {
 
 impl Config {
     /// Reads configuration from file.
-    pub fn read_config() -> Result<Self> {
+    pub fn read_config() -> anyhow::Result<Self> {
         let config_file = config_path();
 
         let data = fs::read(config_file)?;
@@ -33,7 +32,7 @@ impl Config {
 }
 
 /// Returns path to data directory, or creates one if one does not exist. Also checks directory permissions to ensure sensitive data is not readable by others.
-pub fn get_data_dir() -> std::io::Result<PathBuf> {
+pub fn get_data_dir() -> anyhow::Result<PathBuf> {
     let data_dir = if Path::new("data").is_dir() {
         Path::new("data")
     } else if Path::new("/var/lib/clobber").is_dir() {
@@ -71,18 +70,18 @@ fn config_path() -> PathBuf {
 /// Extension trait for `matrix_sdk::Session`. Provides convenience functions for loading and saving sessions.
 pub trait SessionExt: Sized {
     /// Load session from file.
-    fn load_session() -> Result<Self>;
+    fn load_session() -> anyhow::Result<Self>;
     /// Save session to file.
-    fn save_session(&self) -> Result<()>;
+    fn save_session(&self) -> anyhow::Result<()>;
 }
 
 impl SessionExt for matrix_sdk::Session {
-    fn load_session() -> Result<Self> {
+    fn load_session() -> anyhow::Result<Self> {
         let data = fs::read(get_data_dir()?.join("session.json"))?;
         Ok(serde_json::from_slice(&data)?)
     }
 
-    fn save_session(&self) -> Result<()> {
+    fn save_session(&self) -> anyhow::Result<()> {
         let data = serde_json::to_string_pretty(&self)?;
         fs::write(get_data_dir()?.join("session.json"), data)?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // Copyright (C) 2020 Emelie Graven <em@nao.sh>
 // Licensed under the EUPL
 
-use anyhow::Result;
 use clap::{App, Arg};
 use matrix_sdk::{
     room::Room,
@@ -16,6 +15,7 @@ use matrix_sdk::{
 use tracing::{debug, error, info, warn};
 
 pub mod bot;
+pub mod command;
 pub mod config;
 pub mod matrix;
 
@@ -30,7 +30,7 @@ pub const PROGRAM_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 /// Description of the program.
 pub const PROGRAM_DESCRIPTION: &str = env!("CARGO_PKG_DESCRIPTION");
 
-pub async fn init() -> Result<()> {
+pub async fn init() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(tracing_subscriber::fmt().pretty().finish())?;
 
     let args = App::new(PROGRAM_NAME)

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,10 @@
 #![warn(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_errors_doc)]
 
-use anyhow::Result;
 use clobber::init;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     crate::init().await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,9 @@
 
 #![forbid(unsafe_code)]
 #![deny(clippy::all)]
-#![warn(missing_docs)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![warn(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_errors_doc)]
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -8,7 +8,6 @@ use crate::{
     config::{self, Config, SessionExt},
     PROGRAM_NAME, PROGRAM_VERSION,
 };
-use anyhow::Result;
 use matrix_sdk::{reqwest, Client, ClientConfig, Session};
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -28,7 +27,7 @@ pub struct InteractiveLogin {
 
 impl InteractiveLogin {
     /// Interactively collects login information from user via stdin
-    pub fn from_stdin() -> Result<Self> {
+    pub fn from_stdin() -> anyhow::Result<Self> {
         println!("Enter username: ");
         let mut username = String::new();
         io::stdin().read_line(&mut username)?;
@@ -43,7 +42,7 @@ impl InteractiveLogin {
 
 /// Perform initial login with interactive login information collected from user
 #[instrument]
-pub async fn interactive_login() -> Result<Client> {
+pub async fn interactive_login() -> anyhow::Result<Client> {
     debug!("Starting interactive login flow");
     let config = Config::read_config()?;
     // Set device display name to randomized string. Example: "Clobber_vzN2gq"
@@ -89,7 +88,7 @@ pub async fn interactive_login() -> Result<Client> {
 
 /// Restore login from saved session
 #[instrument]
-pub async fn login() -> Result<Client> {
+pub async fn login() -> anyhow::Result<Client> {
     let client_config = client_config()?;
     let config = Config::read_config()?;
     let session = Session::load_session()?;
@@ -103,7 +102,7 @@ pub async fn login() -> Result<Client> {
 }
 
 /// Construct `matrix_sdk` `ClientConfig`
-fn client_config() -> Result<ClientConfig> {
+fn client_config() -> anyhow::Result<ClientConfig> {
     let client_config = ClientConfig::new()
         .user_agent(&format!("{}/{}", PROGRAM_NAME, PROGRAM_VERSION))?
         .store_path(config::get_data_dir()?);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -15,8 +15,10 @@ use rand::Rng;
 use std::io;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, warn};
+use tracing_attributes::instrument;
 
 /// Struct containing info collected from user via interactive login, used for initial login.
+#[derive(Debug)]
 pub struct InteractiveLogin {
     /// Username
     pub username: String,
@@ -40,6 +42,7 @@ impl InteractiveLogin {
 }
 
 /// Perform initial login with interactive login information collected from user
+#[instrument]
 pub async fn interactive_login() -> Result<Client> {
     debug!("Starting interactive login flow");
     let config = Config::read_config()?;
@@ -85,6 +88,7 @@ pub async fn interactive_login() -> Result<Client> {
 }
 
 /// Restore login from saved session
+#[instrument]
 pub async fn login() -> Result<Client> {
     let client_config = client_config()?;
     let config = Config::read_config()?;
@@ -104,20 +108,4 @@ fn client_config() -> Result<ClientConfig> {
         .user_agent(&format!("{}/{}", PROGRAM_NAME, PROGRAM_VERSION))?
         .store_path(config::get_data_dir()?);
     Ok(client_config)
-}
-
-/// Listener struct for incoming matrix events
-pub struct Listener {
-    /// Instance of config::Config
-    pub config: Config,
-    /// Instance of matrix_sdk::Client
-    pub client: Client,
-}
-
-impl Listener {
-    /// Constructor for Listener
-    #[must_use]
-    pub const fn new(config: Config, client: Client) -> Self {
-        Self { config, client }
-    }
 }

--- a/tests/bot.rs
+++ b/tests/bot.rs
@@ -20,7 +20,7 @@ use anyhow::anyhow;
 mod common;
 
 #[tokio::test]
-async fn test() -> anyhow::Result<()> {
+async fn test_() -> anyhow::Result<()> {
     let client = common::get_client().await;
     assert_eq!(
         client.whoami().await?.user_id,
@@ -39,7 +39,7 @@ async fn test_mute() -> anyhow::Result<()> {
             .sync(SyncSettings::default().token(client.sync_token().await.unwrap()))
             .await;
     });
-    let client_target = common::get_client_target().await;
+    let target = common::get_client_target().await;
     let room = client.create_room(Request::new()).await?;
     client.join_room_by_id(&room.room_id).await?;
     let mut delay = 2;
@@ -55,9 +55,9 @@ async fn test_mute() -> anyhow::Result<()> {
             panic!();
         }
     };
-    room.invite_user_by_id(&user_id!("@target:localhost"))
+    room.invite_user_by_id(&user_id!("@target:localhost:6167"))
         .await?;
-    let target_room = client_target.get_room(room.room_id()).unwrap();
+    let target_room = target.get_room(room.room_id()).unwrap();
     if let Room::Invited(target_room) = target_room {
         let mut delay = 2;
         while target_room.accept_invitation().await.is_err() {
@@ -72,11 +72,11 @@ async fn test_mute() -> anyhow::Result<()> {
     }
 
     let content = AnyMessageEventContent::RoomMessage(MessageEventContent::text_plain(
-        "?mute @target:localhost",
+        "?mute @target:localhost:6167",
     ));
     room.send(content, None).await.unwrap();
     let pl = room
-        .get_member(&client_target.user_id().await.unwrap())
+        .get_member(&target.user_id().await.unwrap())
         .await?
         .unwrap()
         .power_level();

--- a/tests/bot.rs
+++ b/tests/bot.rs
@@ -2,9 +2,20 @@
 // Copyright (C) 2020 Emelie Graven <em@nao.sh>
 // Licensed under the EUPL
 
-use std::convert::TryFrom;
+use std::{convert::TryFrom, time::Duration};
 
-use matrix_sdk::ruma::UserId;
+use matrix_sdk::{
+    room::Room,
+    ruma::{
+        api::client::r0::room::create_room::Request,
+        events::{room::message::MessageEventContent, AnyMessageEventContent},
+        user_id, UserId,
+    },
+    SyncSettings,
+};
+use tokio::time::sleep;
+
+use anyhow::anyhow;
 
 mod common;
 
@@ -15,5 +26,61 @@ async fn test() -> anyhow::Result<()> {
         client.whoami().await?.user_id,
         UserId::try_from("@clobber:localhost:6167").unwrap()
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mute() -> anyhow::Result<()> {
+    let client = common::get_client().await;
+    let client_clone = client.clone();
+    let sync = tokio::spawn(async move {
+        let client = client_clone;
+        client
+            .sync(SyncSettings::default().token(client.sync_token().await.unwrap()))
+            .await;
+    });
+    let client_target = common::get_client_target().await;
+    let room = client.create_room(Request::new()).await?;
+    client.join_room_by_id(&room.room_id).await?;
+    let mut delay = 2;
+    let room = loop {
+        if let Some(room) = client.get_joined_room(&room.room_id) {
+            break room;
+        }
+        sleep(Duration::from_secs(delay)).await;
+        delay *= 2;
+
+        if delay > 3600 {
+            anyhow!("Joining room {} timed out", &room.room_id);
+            panic!();
+        }
+    };
+    room.invite_user_by_id(&user_id!("@target:localhost"))
+        .await?;
+    let target_room = client_target.get_room(room.room_id()).unwrap();
+    if let Room::Invited(target_room) = target_room {
+        let mut delay = 2;
+        while target_room.accept_invitation().await.is_err() {
+            sleep(Duration::from_secs(delay)).await;
+            delay *= 2;
+
+            if delay > 3600 {
+                anyhow!("Joining room {} timed out", target_room.room_id());
+                break;
+            }
+        }
+    }
+
+    let content = AnyMessageEventContent::RoomMessage(MessageEventContent::text_plain(
+        "?mute @target:localhost",
+    ));
+    room.send(content, None).await.unwrap();
+    let pl = room
+        .get_member(&client_target.user_id().await.unwrap())
+        .await?
+        .unwrap()
+        .power_level();
+    assert_eq!(pl, -1);
+    sync.abort();
     Ok(())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,13 +4,20 @@
 
 use std::convert::TryFrom;
 
+use clobber::bot;
+use clobber::config::{Bot, Config, Homeserver};
 use matrix_sdk::reqwest::Url;
+use matrix_sdk::room::Room;
 use matrix_sdk::ruma::api::client::r0::account::register::Request as RegistrationRequest;
 use matrix_sdk::ruma::api::client::r0::uiaa::{AuthData, Dummy};
-use matrix_sdk::ruma::assign;
+use matrix_sdk::ruma::events::room::member::MemberEventContent;
+use matrix_sdk::ruma::events::room::message::MessageEventContent;
+use matrix_sdk::ruma::events::{StrippedStateEvent, SyncMessageEvent};
+use matrix_sdk::ruma::{assign, UserId};
 use matrix_sdk::{Client, Session, SyncSettings};
 use tokio::sync::OnceCell;
 static CLIENT: OnceCell<Client> = OnceCell::const_new();
+static CLIENT_TARGET: OnceCell<Client> = OnceCell::const_new();
 
 /// Sets up a  `matrix_sdk::Client` for use within integration tests. By making use of
 /// `tokio::sync::OnceCell`, the first function call will set up a client and register and log in
@@ -19,38 +26,83 @@ static CLIENT: OnceCell<Client> = OnceCell::const_new();
 pub async fn get_client() -> Client {
     CLIENT
         .get_or_init(|| async {
-            let client = Client::new(Url::try_from("http://localhost:6167").unwrap()).unwrap();
-            let mut request = assign!(RegistrationRequest::new(), {
-                username: Some("clobber"),
-                password: Some("foobar"),
-                inhibit_login: false
-            });
-            // Get UIAA session key
-            let uiaa = match client.register(request.clone()).await {
-                Err(e) => match e.uiaa_response().cloned() {
-                    Some(uiaa) => uiaa,
-                    None => panic!("Missing UIAA response 1"),
-                },
-                Ok(_) => {
-                    panic!("Missing UIAA response 2")
-                }
-            };
-            // Set authentication data, m.login.dummy
-            let dummy = assign!(Dummy::new(), {
-                session: uiaa.session.as_deref()
-            });
-            request.auth = Some(AuthData::Dummy(dummy));
-            let response = client.register(request).await.unwrap();
-            let session = Session {
-                access_token: response.access_token.unwrap(),
-                user_id: response.user_id,
-                device_id: response.device_id.unwrap(),
-            };
-            // Not entirely sure why this is necessary but it works ¯\_(ツ)_/¯
-            client.restore_login(session).await.unwrap();
-            client.sync_once(SyncSettings::new()).await.unwrap();
-            client
+            let _ = tracing::subscriber::set_global_default(
+                tracing_subscriber::fmt().pretty().finish(),
+            );
+            init_client("clobber").await
         })
         .await
         .clone()
+}
+
+/// Sets up another `matrix_sdk::Client` like `get_client()` to be used as a moderation target.
+pub async fn get_client_target() -> Client {
+    CLIENT_TARGET
+        .get_or_init(|| async { init_client("target").await })
+        .await
+        .clone()
+}
+
+async fn init_client(username: &str) -> Client {
+    let client = Client::new(Url::try_from("http://localhost:6167").unwrap()).unwrap();
+    let mut request = assign!(RegistrationRequest::new(), {
+        username: Some(username),
+        password: Some("password"),
+        inhibit_login: false
+    });
+    // Get UIAA session key
+    let uiaa = match client.register(request.clone()).await {
+        Err(e) => match e.uiaa_response().cloned() {
+            Some(uiaa) => uiaa,
+            None => panic!("Missing UIAA response 1"),
+        },
+        Ok(_) => {
+            panic!("Missing UIAA response 2")
+        }
+    };
+    // Set authentication data, m.login.dummy
+    let dummy = assign!(Dummy::new(), {
+        session: uiaa.session.as_deref()
+    });
+    request.auth = Some(AuthData::Dummy(dummy));
+    let response = client.register(request).await.unwrap();
+    let session = Session {
+        access_token: response.access_token.unwrap(),
+        user_id: response.user_id,
+        device_id: response.device_id.unwrap(),
+    };
+    // Not entirely sure why this is necessary but it works ¯\_(ツ)_/¯
+    client.restore_login(session).await.unwrap();
+    client.sync_once(SyncSettings::new()).await.unwrap();
+
+    let config = Config {
+        homeserver: Homeserver {
+            url: String::from("http://localhost:6167"),
+        },
+        bot: Bot {
+            command_prefix: String::from("?"),
+            allow_invites: vec![UserId::try_from("@clobber:localhost").unwrap()],
+        },
+    };
+
+    client.register_event_handler(bot::on_room_member).await;
+    client
+        .register_event_handler({
+            let config = config.clone();
+            move |ev: SyncMessageEvent<MessageEventContent>, room: Room, client: Client| {
+                let config = config.clone();
+                async move { bot::on_room_message(ev, room, client, config).await }
+            }
+        })
+        .await;
+    client
+        .register_event_handler({
+            let config = config.clone();
+            move |ev: StrippedStateEvent<MemberEventContent>, room: Room, client: Client| {
+                let config = config.clone();
+                async move { bot::on_stripped_state_member(ev, room, client, config).await }
+            }
+        })
+        .await;
+    client
 }


### PR DESCRIPTION
This PR aims to implement handling of `sh.nao.clobber.rule.server` and `sh.nao.sh.clobber.rule.user` rules.

Rule lists cannot be appropriately implemented until matrix-rust-sdk supports global & room account data. I don't yet have the knowledge required to implement that and submit a PR, so this is blocked waiting on that. A potential workaround is keeping the rule lists as local files, which could work as a temporary solution if the bot gets to a functional state before account data support lands.

TODO:
* [x] Implement rule matching
* [x] Match on `m.room.member` event
* [x] Check members in currently joined rooms when new rule is added
* [x] Take action on match
* [ ] Check that error cases are handled
* [ ] More tests
* [ ] Better documentation